### PR TITLE
PVR addons won't be loaded on pvr-nightly and imx-nightly

### DIFF
--- a/hooks.d/post-clone.d/clone-pvr-addons
+++ b/hooks.d/post-clone.d/clone-pvr-addons
@@ -2,7 +2,7 @@ case $config_source_branch in
   Gotham|gotham_rbp_backports)
     PVR_BRANCH="gotham"
     ;;
-  master)
+  Helix|master)
     PVR_BRANCH="master"
     ;;
 esac


### PR DESCRIPTION
Because there is still no Helix branch in opdenkamps xbmc-pvr-addons, the addons will not be loaded and build on the pvr-nightly and imx-nightly platform.

A change in file hooks.d/post-clone.d/clone-pvr-addons to " Helix|master)" solves this issue
